### PR TITLE
feat(prompt): pass resolved value to onComplete callback

### DIFF
--- a/promptlin-console/src/main/kotlin/me/centauri07/promptlin/console/ConsolePlatformHandler.kt
+++ b/promptlin-console/src/main/kotlin/me/centauri07/promptlin/console/ConsolePlatformHandler.kt
@@ -11,14 +11,14 @@ import me.centauri07.promptlin.core.renderer.renderer
 class ConsolePlatformHandler : PlatformHandler<ConsoleContext>(ConsoleContext::class, renderer) {
     companion object {
         val renderer = renderer<ConsoleContext> {
-            bind<InputPrompt<*>> {
+            bind<Any, InputPrompt<Any>> {
                 onInvoke { ctx, prompt ->
                     ctx.sendOutput("Enter ${prompt.name} (${prompt.description}):")
                     attemptSet(ctx.awaitInput())
                 }
 
-                onComplete { ctx, prompt ->
-                    ctx.sendOutput("Field `${prompt.name}` has been successfully set.")
+                onComplete { value, ctx, prompt ->
+                    ctx.sendOutput("Field `${prompt.name}` has been successfully set to `${value}`.")
                 }
 
                 onFailure { ctx, prompt, e ->

--- a/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/form/FormBuilder.kt
+++ b/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/form/FormBuilder.kt
@@ -27,7 +27,7 @@ abstract class FormBuilder {
      * @param prompt The [Prompt] instance to add.
      * @return The same [prompt] that was added.
      */
-    abstract fun <T> prompt(prompt: Prompt<T>): Prompt<T>
+    abstract fun <T : Any> prompt(prompt: Prompt<T>): Prompt<T>
 
     /**
      * Creates and registers a new input [Prompt] with the form using the given [InputHandler], ID, name,
@@ -49,14 +49,14 @@ abstract class FormBuilder {
      * @param promptBuilder A DSL block to configure validation, conditional inclusion, etc.
      * @return The constructed and registered [Prompt] instance.
      */
-    fun <T> input(
+    inline fun <reified T : Any> input(
         handler: InputHandler<T>,
         id: String,
         name: String,
         description: String,
         promptBuilder: PromptBuilder<T>.() -> Unit = {}
     ): Prompt<T> {
-        val promptBuilderImpl = InputPromptBuilderImpl(handler, id, name, description)
+        val promptBuilderImpl = InputPromptBuilderImpl(handler, T::class, id, name, description)
 
         promptBuilderImpl.promptBuilder()
 

--- a/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/form/FormBuilderImpl.kt
+++ b/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/form/FormBuilderImpl.kt
@@ -6,7 +6,7 @@ class FormBuilderImpl(
     private val prompts: MutableList<Prompt<*>> = mutableListOf()
 ) : FormBuilder() {
 
-    override fun <T> prompt(prompt: Prompt<T>): Prompt<T> {
+    override fun <T : Any> prompt(prompt: Prompt<T>): Prompt<T> {
         prompts += prompt
         return prompt
     }

--- a/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/form/FormSession.kt
+++ b/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/form/FormSession.kt
@@ -1,5 +1,6 @@
 package me.centauri07.promptlin.core.form
 
+import me.centauri07.promptlin.core.prompt.Prompt
 import me.centauri07.promptlin.core.prompt.PromptInstance
 import me.centauri07.promptlin.core.renderer.RenderContext
 import me.centauri07.promptlin.core.renderer.Renderer
@@ -31,7 +32,7 @@ class FormSession<C : RenderContext>(
      * These wrap each [me.centauri07.promptlin.core.prompt.Prompt] in the form and track its answered state.
      */
     val promptInstances: List<PromptInstance<*>> = form.prompts.map {
-        PromptInstance(it, scope)
+        PromptInstance(it as Prompt<Any>, scope)
     }
 
     /**

--- a/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/form/FormSessionScope.kt
+++ b/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/form/FormSessionScope.kt
@@ -13,11 +13,11 @@ import me.centauri07.promptlin.core.prompt.Prompt
  */
 class FormSessionScope(private val formSession: FormSession<*>) {
     @Suppress("UNCHECKED_CAST")
-    fun <T> get(prompt: Prompt<T>): T = formSession.promptInstances.first { it.prompt.id == prompt.id }.value!! as T
+    fun <T : Any> get(prompt: Prompt<T>): T = formSession.promptInstances.first { it.prompt.id == prompt.id }.value!! as T
 
-    fun <T> getOrElse(prompt: Prompt<T>, defaultValue: (Prompt<T>) -> T) : T = getOrNull(prompt) ?: defaultValue(prompt)
+    fun <T : Any> getOrElse(prompt: Prompt<T>, defaultValue: (Prompt<T>) -> T) : T = getOrNull(prompt) ?: defaultValue(prompt)
 
-    fun <T> getOrNull(prompt: Prompt<T>) : T? = runCatching { get(prompt) }.getOrNull()
+    fun <T : Any> getOrNull(prompt: Prompt<T>) : T? = runCatching { get(prompt) }.getOrNull()
 
     @Suppress("UNCHECKED_CAST")
     fun <T> get(promptId: String): T = formSession.promptInstances.first { it.prompt.id == promptId }.value!! as T

--- a/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/prompt/Prompt.kt
+++ b/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/prompt/Prompt.kt
@@ -1,6 +1,7 @@
 package me.centauri07.promptlin.core.prompt
 
 import me.centauri07.promptlin.core.form.FormSessionScope
+import kotlin.reflect.KClass
 
 /**
  * Represents an abstract prompt that collects, parses, and validates user input of type [T].
@@ -10,7 +11,8 @@ import me.centauri07.promptlin.core.form.FormSessionScope
  * @property description A short description explaining the purpose of the prompt.
  * @param shouldInclude A lambda that determines whether this prompt should be included in the current context.
  */
-abstract class Prompt<T>(
+abstract class Prompt<T : Any>(
+    val valueType: KClass<T>,
     val id: String,
     val name: String,
     val description: String,

--- a/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/prompt/PromptInstance.kt
+++ b/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/prompt/PromptInstance.kt
@@ -13,7 +13,7 @@ import me.centauri07.promptlin.core.form.FormSessionScope
  * @property prompt The [Prompt] definition this instance wraps.
  * @property formSessionScope Provides access to the current session's state for validation or inclusion logic.
  */
-class PromptInstance<T>(val prompt: Prompt<T>, private val formSessionScope: FormSessionScope) {
+class PromptInstance<T : Any>(val prompt: Prompt<T>, private val formSessionScope: FormSessionScope) {
     /**
      * The parsed and validated value provided by the user.
      *

--- a/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/prompt/input/InputPrompt.kt
+++ b/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/prompt/input/InputPrompt.kt
@@ -2,6 +2,7 @@ package me.centauri07.promptlin.core.prompt.input
 
 import me.centauri07.promptlin.core.form.FormSessionScope
 import me.centauri07.promptlin.core.prompt.Prompt
+import kotlin.reflect.KClass
 
 /**
  * A [Prompt] that uses a [InputHandler] to parse user input from a string into type [T].
@@ -11,14 +12,15 @@ import me.centauri07.promptlin.core.prompt.Prompt
  * @param name The name of the prompt.
  * @param description A description to help users understand what the prompt is asking for.
  */
-class InputPrompt<T>(
+class InputPrompt<T : Any>(
     private val handler: InputHandler<T>,
+    valueType: KClass<T>,
     id: String,
     name: String,
     description: String,
     validators: MutableList<Validator<T>>,
     shouldInclude: FormSessionScope.() -> Boolean
-) : Prompt<T>(id, name, description, validators, shouldInclude) {
+) : Prompt<T>(valueType, id, name, description, validators, shouldInclude) {
 
     /**
      * Parses the provided [input] using the configured [InputHandler].

--- a/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/prompt/input/InputPromptBuilderImpl.kt
+++ b/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/prompt/input/InputPromptBuilderImpl.kt
@@ -2,16 +2,18 @@ package me.centauri07.promptlin.core.prompt.input
 
 import me.centauri07.promptlin.core.prompt.Prompt
 import me.centauri07.promptlin.core.prompt.PromptBuilderImpl
+import kotlin.reflect.KClass
 
-class InputPromptBuilderImpl<T>(
+class InputPromptBuilderImpl<T : Any>(
     private val handler: InputHandler<T>,
+    private val valueType: KClass<T>,
     private val id: String,
     private val name: String,
     private val description: String
 ) : PromptBuilderImpl<T>() {
 
     fun build(): Prompt<T> {
-        return InputPrompt(handler, id, name, description, validators, shouldInclude)
+        return InputPrompt(handler, valueType, id, name, description, validators, shouldInclude)
     }
 
 }

--- a/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/renderer/RenderBinding.kt
+++ b/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/renderer/RenderBinding.kt
@@ -4,10 +4,11 @@ import me.centauri07.promptlin.core.prompt.PromptInstanceScope
 import me.centauri07.promptlin.core.prompt.Prompt
 import kotlin.reflect.KClass
 
-data class RenderBinding<P : Prompt<*>, C : RenderContext>(
+data class RenderBinding<T : Any, P : Prompt<*>, C : RenderContext>(
+    val valueType: KClass<T>,
     val promptType: KClass<out P>,
     val contextType: KClass<out C>,
     val onInvoke: PromptInstanceScope.(C, P) -> Unit,
-    val onComplete: PromptInstanceScope.(C, P) -> Unit,
+    val onComplete: PromptInstanceScope.(T, C, P) -> Unit,
     val onFailure: PromptInstanceScope.(C, P, Throwable) -> Unit
 )

--- a/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/renderer/RenderBindingBuilder.kt
+++ b/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/renderer/RenderBindingBuilder.kt
@@ -30,7 +30,7 @@ import me.centauri07.promptlin.core.prompt.Prompt
  * @see RenderBinding
  */
 @BuilderDsl
-abstract class RenderBindingBuilder<P : Prompt<*>, C : RenderContext> {
+abstract class RenderBindingBuilder<T : Any, P : Prompt<T>, C : RenderContext> {
     /**
      * Defines the behavior that occurs when the prompt is first invoked.
      *
@@ -43,7 +43,7 @@ abstract class RenderBindingBuilder<P : Prompt<*>, C : RenderContext> {
      *
      * @param block the logic to execute on successful completion
      */
-    abstract fun onComplete(block: PromptInstanceScope.(C, P) -> Unit)
+    abstract fun onComplete(block: PromptInstanceScope.(T, C, P) -> Unit)
 
     /**
      * Defines the behavior that occurs when an exception is thrown during prompt processing.

--- a/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/renderer/RenderBindingBuilderImpl.kt
+++ b/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/renderer/RenderBindingBuilderImpl.kt
@@ -1,22 +1,23 @@
 package me.centauri07.promptlin.core.renderer
 
+import com.sun.jdi.Type
 import me.centauri07.promptlin.core.prompt.PromptInstanceScope
 import me.centauri07.promptlin.core.prompt.Prompt
 import kotlin.reflect.KClass
 
-class RenderBindingBuilderImpl<P : Prompt<*>, C : RenderContext>(
-    private val promptType: KClass<P>, private val contextType: KClass<C>
-) : RenderBindingBuilder<P, C>() {
+class RenderBindingBuilderImpl<T : Any, P : Prompt<T>, C : RenderContext>(
+    private val valueType: KClass<T>, private val promptType: KClass<P>, private val contextType: KClass<C>
+) : RenderBindingBuilder<T, P, C>() {
 
     var onInvoke: PromptInstanceScope.(C, P) -> Unit = { _, _ -> }
-    var onComplete: PromptInstanceScope.(C, P) -> Unit = { _, _ -> }
-    var onFailure: PromptInstanceScope.(C, P, Throwable) -> Unit = { _, _, _-> }
+    var onComplete: PromptInstanceScope.(T, C, P) -> Unit = { _, _, _ -> }
+    var onFailure: PromptInstanceScope.(C, P, Throwable) -> Unit = { _, _, _ -> }
 
     override fun onInvoke(block: PromptInstanceScope.(C, P) -> Unit) {
         onInvoke = block
     }
 
-    override fun onComplete(block: PromptInstanceScope.(C, P) -> Unit) {
+    override fun onComplete(block: PromptInstanceScope.(T, C, P) -> Unit) {
         onComplete = block
     }
 
@@ -24,7 +25,7 @@ class RenderBindingBuilderImpl<P : Prompt<*>, C : RenderContext>(
         onFailure = block
     }
 
-    fun build(): RenderBinding<P, C> = RenderBinding(
-        promptType, contextType, onInvoke, onComplete, onFailure
+    fun build(): RenderBinding<T, P, C> = RenderBinding(
+        valueType, promptType, contextType, onInvoke, onComplete, onFailure
     )
 }

--- a/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/renderer/RenderContext.kt
+++ b/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/renderer/RenderContext.kt
@@ -1,7 +1,7 @@
 package me.centauri07.promptlin.core.renderer
 
 /**
- * Represents the context in which a [Prompt] is rendered.
+ * Represents the context in which a [me.centauri07.promptlin.core.prompt.Prompt] is rendered.
  *
  * Subclasses of [RenderContext] define the platform-specific rendering environment and behavior—
  * such as console, web UI, Discord, or other I/O mechanisms.

--- a/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/renderer/RendererBuilder.kt
+++ b/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/renderer/RendererBuilder.kt
@@ -32,7 +32,11 @@ abstract class RendererBuilder<C : RenderContext>() {
      * @param promptType the [KClass] of the prompt
      * @param block the configuration block for building the render logic
      */
-    abstract fun <P : Prompt<*>> bind(promptType: KClass<P>, block: RenderBindingBuilder<P, C>.() -> Unit)
+    abstract fun <T : Any, P : Prompt<T>> bind(
+        valueType: KClass<T>,
+        promptType: KClass<P>,
+        block: RenderBindingBuilder<T, P, C>.() -> Unit
+    )
 
     /**
      * Registers a render binding for the given [Prompt] type using a reified type parameter.
@@ -42,9 +46,9 @@ abstract class RendererBuilder<C : RenderContext>() {
      * @param P the type of [Prompt]
      * @param block the configuration block for building the render logic
      */
-    inline fun <reified P : Prompt<*>> bind(
-        noinline block: RenderBindingBuilder<P, C>.() -> Unit
+    inline fun <reified T : Any, reified P : Prompt<T>> bind(
+        noinline block: RenderBindingBuilder<T, P, C>.() -> Unit
     ) {
-        bind(P::class, block)
+        bind(T::class, P::class, block)
     }
 }

--- a/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/renderer/RendererBuilderImpl.kt
+++ b/promptlin-core/src/main/kotlin/me/centauri07/promptlin/core/renderer/RendererBuilderImpl.kt
@@ -10,14 +10,15 @@ import kotlin.reflect.KClass
 @BuilderDsl
 class RendererBuilderImpl<C : RenderContext>(
     private val contextType: KClass<C>,
-    private val bindings: MutableList<RenderBinding<*, C>> = mutableListOf()
+    private val bindings: MutableList<RenderBinding<*, out Prompt<*>, C>> = mutableListOf()
 ) : RendererBuilder<C>() {
 
-    override fun <P : Prompt<*>> bind(
+    override fun <T : Any, P : Prompt<T>> bind(
+        valueType: KClass<T>,
         promptType: KClass<P>,
-        block: RenderBindingBuilder<P, C>.() -> Unit
+        block: RenderBindingBuilder<T, P, C>.() -> Unit
     ) {
-        val renderBinding = RenderBindingBuilderImpl(promptType, contextType)
+        val renderBinding = RenderBindingBuilderImpl(valueType, promptType, contextType)
 
         renderBinding.block()
 


### PR DESCRIPTION
The `onComplete` callback now includes the resolved prompt value as a parameter:

Before:
    `onComplete { ctx, prompt -> ... }``

After:
    `onComplete { value, ctx, prompt -> ... }`

This allows better feedback and post-processing logic after a prompt is completed.